### PR TITLE
the addEvent corrected the internal name to "setEvent"

### DIFF
--- a/xajax_js/xajax_core_uncompressed.js
+++ b/xajax_js/xajax_core_uncompressed.js
@@ -334,7 +334,10 @@ xajax.tools = {}
 xajax.tools.$ = function(sId) {
 	if (!sId)
 		return null;
-	
+    //sId not an string so return it maybe its an object.
+	if(typeof sId != 'string')
+        return sId;
+
 	var oDoc = xajax.config.baseDocument;
 
 	var obj = oDoc.getElementById(sId);


### PR DESCRIPTION
the type checking of the element was removed
xjx.$(); checks the element and gets the DOM object back
function(e) was stetted, now an "click" will be transported inside the function if needed
