### PR TITLE
Changes to xajax_core.js

### DIFF
--- a/acompress.php
+++ b/acompress.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * 2012-01-23
+ * Trying out html name array
+ */
+//Setup the xajax framework.
+include_once("xajax_core/xajax.inc.php");
+$xajax = new xajax();
+$xajax->autoCompressJavascript(NULL, true);

--- a/acompress.php
+++ b/acompress.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * 2012-01-23
- * Trying out html name array
+ * xajax js compress tool
  */
 //Setup the xajax framework.
 include_once("xajax_core/xajax.inc.php");

--- a/xajax_js/xajax_core.js
+++ b/xajax_js/xajax_core.js
@@ -87,10 +87,10 @@ return;var name=child.name;var values=[];if('select-multiple'==child.type){var j
 values.push(option.value);}
 }else{values=child.value;}
 var keyBegin=name.indexOf('[');if(0 <=keyBegin){var n=name;var k=n.substr(0,n.indexOf('['));var a=n.substr(n.indexOf('['));if(typeof aFormValues[k]=='undefined')
-aFormValues[k]=[];var p=aFormValues;while(a.length!=0){var sa=a.substr(0,a.indexOf(']')+1);var lk=k;var lp=p;a=a.substr(a.indexOf(']')+1);p=p[k];k=sa.substr(1,sa.length-2);if(k==''){if('select-multiple'==child.type){k=lk;p=lp;}else{k=p.length;}
+aFormValues[k]=a=='[]' ? []:{};var p=aFormValues;while(a.length!=0){var sa=a.substr(0,a.indexOf(']')+1);var lk=k;var lp=p;a=a.substr(a.indexOf(']')+1);p=p[k];k=sa.substr(1,sa.length-2);if(k==''){if('select-multiple'==child.type){k=lk;p=lp;}else{k=p.length;}
 }
 if(typeof p[k]=='undefined')
-p[k]=[];}
+p[k]=a=='[]' ? []:{};}
 p[k]=values;}else{aFormValues[name]=values;}
 }
 xajax.tools.stripOnPrefix=function(sEventName){sEventName=sEventName.toLowerCase();if(0==sEventName.indexOf('on'))

--- a/xajax_js/xajax_core_uncompressed.js
+++ b/xajax_js/xajax_core_uncompressed.js
@@ -11,6 +11,10 @@
 	
 	Please see <copyright.inc.php> for a detailed description, copyright
 	and license information.
+  
+  12-14-2013 Ed Robinson
+  altered _getFormValue to return alpha array indexes instead of empty array
+  at lines 873 and 894
 */
 
 /*
@@ -867,7 +871,8 @@ xajax.tools._getFormValue = function(aFormValues, child, submitDisabledElements,
 		var k = n.substr(0, n.indexOf('['));
 		var a = n.substr(n.indexOf('['));
 		if (typeof aFormValues[k] == 'undefined')
-			aFormValues[k] = [];
+			//aFormValues[k] = [];
+      aFormValues[k] = a == '[]' ? [] : {};
 		var p = aFormValues; // pointer reset
 		while (a.length != 0) {
 			var sa = a.substr(0, a.indexOf(']')+1);
@@ -887,7 +892,8 @@ xajax.tools._getFormValue = function(aFormValues, child, submitDisabledElements,
 				}
 			}
 			if (typeof p[k] == 'undefined')
-				p[k] = []; 
+				//p[k] = []; 
+        p[k] = a == '[]' ? [] : {};
 		}
 		p[k] = values;
 	} else {


### PR DESCRIPTION
I have encountered a number of posts on the xajax forum complaining about xajax0.6 handles array syntax in form element names. Prior to this change the xhr contained [] for the bracketed fields.

The change causes field[abc] and field[def] to be submitted as an array with the proper keys.

I also created a simple php tool to re-compress the uncompressed js after a modification.
