### PR TITLE
fix deprecated constructors

### DIFF
--- a/xajax_core/plugin_layer/support/xajaxUserFunction.inc.php
+++ b/xajax_core/plugin_layer/support/xajaxUserFunction.inc.php
@@ -106,7 +106,7 @@ final class xajaxUserFunction
 				
 			$xajax->register(XAJAX_FUNCTION, $myUserFunction);				
 	*/
-	public function xajaxUserFunction($uf) // /*deprecated parameters */ $sInclude=NULL, $aConfiguration=array())
+	public function __construct($uf) // /*deprecated parameters */ $sInclude=NULL, $aConfiguration=array())
 	{
 		$this->sAlias = '';
 		$this->uf = $uf;

--- a/xajax_core/plugin_layer/xajaxDefaultIncludePlugin.inc.php
+++ b/xajax_core/plugin_layer/xajaxDefaultIncludePlugin.inc.php
@@ -30,11 +30,6 @@ final class xajaxIncludeClientScriptPlugin extends xajaxRequestPlugin
 {
 
 
-	public function xajaxIncludeClientScriptPlugin()
-	{
-
-	}
-
 	/*
 		Function: configure
 	*/

--- a/xajax_core/plugin_layer/xajaxEventPlugin.inc.php
+++ b/xajax_core/plugin_layer/xajaxEventPlugin.inc.php
@@ -1,1 +1,231 @@
-<?php/*	File: xajaxEventPlugin.inc.php	Contains the xajaxEventPlugin class	Title: xajaxEventPlugin class	Please see <copyright.inc.php> for a detailed description, copyright	and license information.*//*	@package xajax	@version $Id: xajaxEventPlugin.inc.php 362 2007-05-29 15:32:24Z calltoconstruct $	@copyright Copyright (c) 2005-2007 by Jared White & J. Max Wilson	@copyright Copyright (c) 2008-2009 by Joseph Woolley, Steffen Konerow, Jared White  & J. Max Wilson	@license http://www.xajaxproject.org/bsd_license.txt BSD License*//*	Constant: XAJAX_EVENT		Specifies that the item being registered via the <xajax->register> function		is an event.			Constant: XAJAX_EVENT_HANDLER		Specifies that the item being registered via the <xajax->register> function		is an event handler.*/if (!defined ('XAJAX_EVENT')) define ('XAJAX_EVENT', 'xajax event');if (!defined ('XAJAX_EVENT_HANDLER')) define ('XAJAX_EVENT_HANDLER', 'xajax event handler');//SkipAIOrequire dirname(__FILE__) . '/support/xajaxEvent.inc.php';//EndSkipAIO/*	Class: xajaxEventPlugin		Plugin that adds server side event handling capabilities to xajax.  Events can	be registered, then event handlers attached.*/class xajaxEventPlugin extends xajaxRequestPlugin{	/*		Array: aEvents	*/	var $aEvents;	/*		String: sXajaxPrefix	*/	var $sXajaxPrefix;		/*		String: sEventPrefix	*/	var $sEventPrefix;	/*		String: sDefer	*/	var $sDefer;		var $bDeferScriptGeneration;	/*		String: sRequestedEvent	*/	var $sRequestedEvent;	/*		Function: xajaxEventPlugin	*/	function xajaxEventPlugin()	{		$this->aEvents = array();		$this->sXajaxPrefix = 'xajax_';		$this->sEventPrefix = 'event_';		$this->sDefer = '';		$this->bDeferScriptGeneration = false;		$this->sRequestedEvent = NULL;		if (isset($_GET['xjxevt'])) $this->sRequestedEvent = $_GET['xjxevt'];		if (isset($_POST['xjxevt'])) $this->sRequestedEvent = $_POST['xjxevt'];	}	/*		Function: configure	*/	function configure($sName, $mValue)	{		if ('wrapperPrefix' == $sName) {			$this->sXajaxPrefix = $mValue;		} else if ('eventPrefix' == $sName) {			$this->sEventPrefix = $mValue;		} else if ('scriptDefferal' == $sName) {			if (true === $mValue) $this->sDefer = 'defer ';			else $this->sDefer = '';		} else if ('deferScriptGeneration' == $sName) {			if (true === $mValue || false === $mValue)				$this->bDeferScriptGeneration = $mValue;			else if ('deferred' === $mValue)				$this->bDeferScriptGeneration = true;		}	}	/*		Function: register		$sType - (string): type of item being registered		$sEvent - (string): the name of the event		$ufHandler - (function name or reference): a reference to the user function to call		$aConfiguration - (array): an array containing configuration options	*/	function register($aArgs)	{		if (1 < count($aArgs))		{			$sType = $aArgs[0];			if (XAJAX_EVENT == $sType)			{				$sEvent = $aArgs[1];				if (false === isset($this->aEvents[$sEvent]))				{					$xe = new xajaxEvent($sEvent);					if (2 < count($aArgs))						if (is_array($aArgs[2]))							foreach ($aArgs[2] as $sKey => $sValue)								$xe->configure($sKey, $sValue);					$this->aEvents[$sEvent] =& $xe;					return $xe->generateRequest($this->sXajaxPrefix, $this->sEventPrefix);				}			}			if (XAJAX_EVENT_HANDLER == $sType)			{				$sEvent = $aArgs[1];				if (isset($this->aEvents[$sEvent]))				{					if (isset($aArgs[2]))					{						$xuf =& $aArgs[2];						if (false === ($xuf instanceof xajaxUserFunction))							$xuf = new xajaxUserFunction($xuf);						$objEvent =& $this->aEvents[$sEvent];						$objEvent->addHandler($xuf);						return true;					}				}			}		}		return false;	}	function generateHash()	{		$sHash = '';		foreach (array_keys($this->aEvents) as $sKey)			$sHash .= $this->aEvents[$sKey]->getName();		return md5($sHash);	}	/*		Function: generateClientScript	*/	function generateClientScript()	{		foreach (array_keys($this->aEvents) as $sKey)			$this->aEvents[$sKey]->generateClientScript($this->sXajaxPrefix, $this->sEventPrefix);	}	/*		Function: canProcessRequest	*/	function canProcessRequest()	{		if (NULL == $this->sRequestedEvent)			return false;		return true;	}	/*		Function: processRequest	*/	function processRequest()	{		if (NULL == $this->sRequestedEvent)			return false;		$objArgumentManager =& xajaxArgumentManager::getInstance();		$aArgs = $objArgumentManager->process();				foreach (array_keys($this->aEvents) as $sKey)		{			$objEvent =& $this->aEvents[$sKey];			if ($objEvent->getName() == $this->sRequestedEvent)			{				$objEvent->fire($aArgs);				return true;			}		}		return 'Invalid event request received; no event was registered with this name.';	}}$objPluginManager =& xajaxPluginManager::getInstance();$objPluginManager->registerPlugin(new xajaxEventPlugin(), 103);
+<?php
+/*
+	File: xajaxEventPlugin.inc.php
+
+	Contains the xajaxEventPlugin class
+
+	Title: xajaxEventPlugin class
+
+	Please see <copyright.inc.php> for a detailed description, copyright
+	and license information.
+*/
+
+/*
+	@package xajax
+	@version $Id: xajaxEventPlugin.inc.php 362 2007-05-29 15:32:24Z calltoconstruct $
+	@copyright Copyright (c) 2005-2007 by Jared White & J. Max Wilson
+	@copyright Copyright (c) 2008-2009 by Joseph Woolley, Steffen Konerow, Jared White  & J. Max Wilson
+	@license http://www.xajaxproject.org/bsd_license.txt BSD License
+*/
+
+/*
+	Constant: XAJAX_EVENT
+		Specifies that the item being registered via the <xajax->register> function
+		is an event.
+		
+	Constant: XAJAX_EVENT_HANDLER
+		Specifies that the item being registered via the <xajax->register> function
+		is an event handler.
+*/
+if (!defined ('XAJAX_EVENT')) define ('XAJAX_EVENT', 'xajax event');
+if (!defined ('XAJAX_EVENT_HANDLER')) define ('XAJAX_EVENT_HANDLER', 'xajax event handler');
+
+//SkipAIO
+require dirname(__FILE__) . '/support/xajaxEvent.inc.php';
+//EndSkipAIO
+
+/*
+	Class: xajaxEventPlugin
+	
+	Plugin that adds server side event handling capabilities to xajax.  Events can
+	be registered, then event handlers attached.
+*/
+class xajaxEventPlugin extends xajaxRequestPlugin
+{
+	/*
+		Array: aEvents
+	*/
+	var $aEvents;
+
+	/*
+		String: sXajaxPrefix
+	*/
+	var $sXajaxPrefix;
+	
+	/*
+		String: sEventPrefix
+	*/
+	var $sEventPrefix;
+
+	/*
+		String: sDefer
+	*/
+	var $sDefer;
+	
+	var $bDeferScriptGeneration;
+
+	/*
+		String: sRequestedEvent
+	*/
+	var $sRequestedEvent;
+
+	/*
+		Function: xajaxEventPlugin
+	*/
+	function __construct()
+	{
+		$this->aEvents = array();
+
+		$this->sXajaxPrefix = 'xajax_';
+		$this->sEventPrefix = 'event_';
+		$this->sDefer = '';
+		$this->bDeferScriptGeneration = false;
+
+		$this->sRequestedEvent = NULL;
+
+		if (isset($_GET['xjxevt'])) $this->sRequestedEvent = $_GET['xjxevt'];
+		if (isset($_POST['xjxevt'])) $this->sRequestedEvent = $_POST['xjxevt'];
+	}
+
+	/*
+		Function: configure
+	*/
+	function configure($sName, $mValue)
+	{
+		if ('wrapperPrefix' == $sName) {
+			$this->sXajaxPrefix = $mValue;
+		} else if ('eventPrefix' == $sName) {
+			$this->sEventPrefix = $mValue;
+		} else if ('scriptDefferal' == $sName) {
+			if (true === $mValue) $this->sDefer = 'defer ';
+			else $this->sDefer = '';
+		} else if ('deferScriptGeneration' == $sName) {
+			if (true === $mValue || false === $mValue)
+				$this->bDeferScriptGeneration = $mValue;
+			else if ('deferred' === $mValue)
+				$this->bDeferScriptGeneration = true;
+		}
+	}
+
+	/*
+		Function: register
+
+		$sType - (string): type of item being registered
+		$sEvent - (string): the name of the event
+		$ufHandler - (function name or reference): a reference to the user function to call
+		$aConfiguration - (array): an array containing configuration options
+	*/
+	function register($aArgs)
+	{
+		if (1 < count($aArgs))
+		{
+			$sType = $aArgs[0];
+
+			if (XAJAX_EVENT == $sType)
+			{
+				$sEvent = $aArgs[1];
+
+				if (false === isset($this->aEvents[$sEvent]))
+				{
+					$xe = new xajaxEvent($sEvent);
+
+					if (2 < count($aArgs))
+						if (is_array($aArgs[2]))
+							foreach ($aArgs[2] as $sKey => $sValue)
+								$xe->configure($sKey, $sValue);
+
+					$this->aEvents[$sEvent] =& $xe;
+
+					return $xe->generateRequest($this->sXajaxPrefix, $this->sEventPrefix);
+				}
+			}
+
+			if (XAJAX_EVENT_HANDLER == $sType)
+			{
+				$sEvent = $aArgs[1];
+
+				if (isset($this->aEvents[$sEvent]))
+				{
+					if (isset($aArgs[2]))
+					{
+						$xuf =& $aArgs[2];
+
+						if (false === ($xuf instanceof xajaxUserFunction))
+							$xuf = new xajaxUserFunction($xuf);
+
+						$objEvent =& $this->aEvents[$sEvent];
+						$objEvent->addHandler($xuf);
+
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+
+	function generateHash()
+	{
+		$sHash = '';
+
+		foreach (array_keys($this->aEvents) as $sKey)
+			$sHash .= $this->aEvents[$sKey]->getName();
+		return md5($sHash);
+	}
+
+	/*
+		Function: generateClientScript
+	*/
+	function generateClientScript()
+	{
+
+		foreach (array_keys($this->aEvents) as $sKey)
+			$this->aEvents[$sKey]->generateClientScript($this->sXajaxPrefix, $this->sEventPrefix);
+
+	}
+
+	/*
+		Function: canProcessRequest
+	*/
+	function canProcessRequest()
+	{
+		if (NULL == $this->sRequestedEvent)
+			return false;
+
+		return true;
+	}
+
+	/*
+		Function: processRequest
+	*/
+	function processRequest()
+	{
+		if (NULL == $this->sRequestedEvent)
+			return false;
+
+		$objArgumentManager =& xajaxArgumentManager::getInstance();
+		$aArgs = $objArgumentManager->process();
+		
+
+
+		foreach (array_keys($this->aEvents) as $sKey)
+		{
+			$objEvent =& $this->aEvents[$sKey];
+
+			if ($objEvent->getName() == $this->sRequestedEvent)
+			{
+				$objEvent->fire($aArgs);
+				return true;
+			}
+		}
+
+		return 'Invalid event request received; no event was registered with this name.';
+	}
+}
+
+$objPluginManager =& xajaxPluginManager::getInstance();
+$objPluginManager->registerPlugin(new xajaxEventPlugin(), 103);
+
+?>

--- a/xajax_core/plugin_layer/xajaxFunctionPlugin.inc.php
+++ b/xajax_core/plugin_layer/xajaxFunctionPlugin.inc.php
@@ -81,7 +81,7 @@ class xajaxFunctionPlugin extends xajaxRequestPlugin
 		be used to determine if the request is for a registered function in
 		<xajaxFunctionPlugin->canProcessRequest>
 	*/
-	function xajaxFunctionPlugin()
+	function __construct()
 	{
 		$this->aFunctions = array();
 

--- a/xajax_core/plugin_layer/xajaxScriptPlugin.inc.php
+++ b/xajax_core/plugin_layer/xajaxScriptPlugin.inc.php
@@ -68,7 +68,7 @@ class xajaxScriptPlugin extends xajaxRequestPlugin
 		GET data (parameters passed on the request URI) and store them
 		for later use.
 	*/
-	function xajaxScriptPlugin()
+	function __function()
 	{
 		$this->sRequestURI = '';
 		$this->bDeferScriptGeneration = false;

--- a/xajax_core/xajaxRequest.inc.php
+++ b/xajax_core/xajaxRequest.inc.php
@@ -312,8 +312,9 @@ class xajaxCustomRequest extends xajaxRequest
 		aVariables - (associative array, optional):  An array of variable name, 
 			value pairs that will be passed to <xajaxCustomRequest->setVariable>
 	*/
-	function xajaxCustomRequest($sScript)
+	function __construct($sScript)
 	{
+		parent::__construct();
 		$this->aVariables = array();
 		$this->sScript = $sScript;
 	}

--- a/xajax_core/xajaxResponse.inc.php
+++ b/xajax_core/xajaxResponse.inc.php
@@ -1974,8 +1974,9 @@ class xajaxCustomResponse
 	protected $sCharacterEncoding;
 	protected $bOutputEntities;
 	
-	function xajaxCustomResponse($sContentType)
+	function __construct($sContentType)
 	{
+		parent::__construct();
 		$this->sOutput = '';
 		$this->sContentType = $sContentType;
 		


### PR DESCRIPTION
In PHP7, old-style constructors are deprecated and will give a warning: "Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP".

This PR renames the constructors and fixes the line-breaks for `xajax_core/plugin_layer/xajaxEventPlugin.inc.php`.

Fixes #40.